### PR TITLE
added ability to supply functions that return strings describing errors

### DIFF
--- a/man/assert_create.Rd
+++ b/man/assert_create.Rd
@@ -4,14 +4,16 @@
 \alias{assert_create}
 \title{Create an assertion function}
 \usage{
-assert_create(func, default_error_msg)
+assert_create(func, default_error_msg = NULL)
 }
 \arguments{
 \item{func}{A function defining the assertion criteria. This function should
-return a logical value (\code{TRUE} when assertion is passed or \code{FALSE} when it fails)}
+return a logical value (\code{TRUE} when assertion is passed or \code{FALSE} when it fails).
+Alternatively, instead of returning FALSE, you can return a string which will act as the error message.
+In this latter case, you don't need to supply a \code{default_error_msg}}
 
 \item{default_error_msg}{A character string providing an error message in case
-the assertion fails.
+the assertion fails. Must be supplied if function \code{func} returns \code{FALSE} when assertion fails (as opposed to a string)
 Can include the following special terms
 \enumerate{
 \item \code{{arg_name}} to refer to the name of the variable supplied to the assertion.

--- a/tests/testthat/_snaps/assert_create.md
+++ b/tests/testthat/_snaps/assert_create.md
@@ -1,0 +1,63 @@
+# assertion function aborts if func does not return a logical scalar when default_error_msg is supplied [plain]
+
+    Code
+      assert_is_numeric(2)
+    Error <rlang_error>
+      Assertion Function `function(x) x` must return TRUE if assertion passes and FALSE or a String if assertion should fail. Instead returned: `2`
+
+# assertion function aborts if func returns FALSE without a default error message [plain]
+
+    Code
+      bad_assert_no_default_error(2)
+    Error <rlang_error>
+      Assertion Function `function(x) FALSE` returned FALSE, indicating assertion should fail, however no `default_error_msg` was supplied! Please add a `default_error_msg` to your assert_create call, or change function to return a string describing the error instead of `FALSE`
+
+---
+
+    Code
+      good_assert_no_default_error(2)
+    Error <rlang_error>
+      an error message
+
+# assertion function throws appropriate error when returning neither a flag NOR a string [plain]
+
+    Code
+      bad_assert_returns_char("foo")
+    Error <rlang_error>
+      Assertion Function `function(x) c("a", "b")` must return TRUE if assertion passes and FALSE or a String if assertion should fail. Instead returned: `a and b`
+
+---
+
+    Code
+      bad_assert_returns_logical("foo")
+    Error <rlang_error>
+      Assertion Function `function(x) c(TRUE, TRUE)` must return TRUE if assertion passes and FALSE or a String if assertion should fail. Instead returned: `TRUE and TRUE`
+
+---
+
+    Code
+      bad_assert_returns_factor("foo")
+    Error <rlang_error>
+      Assertion Function `function(x) factor(c(1, 4))` must return TRUE if assertion passes and FALSE or a String if assertion should fail. Instead returned: `1 and 4`
+
+# assertion function works as expected with string-returning assertion functions [plain]
+
+    Code
+      assert_between_min_and_max("foo", min = 3, max = 5)
+    Error <rlang_error>
+      "foo" is a character, not numeric
+
+---
+
+    Code
+      assert_between_min_and_max(6, min = 3, max = 5)
+    Error <rlang_error>
+      6 is over 5
+
+---
+
+    Code
+      assert_between_min_and_max(2, min = 3, max = 5)
+    Error <rlang_error>
+      2 is under 3
+

--- a/tests/testthat/test-assert_create.R
+++ b/tests/testthat/test-assert_create.R
@@ -33,10 +33,56 @@ cli::test_that_cli(configs = "plain", "assert_create() aborts if default_error_m
   expect_error(assert_create(is.numeric, 1), "1 must be a string (length 1 character vector). Class: numeric; Length: 1", fixed=TRUE)
 })
 
-cli::test_that_cli(configs = "plain", "assertion function aborts if func does not return a logical scalar", {
+cli::test_that_cli(configs = "plain", "assertion function aborts if func does not return a logical scalar when default_error_msg is supplied", {
   assert_is_numeric <- assert_create(function(x) x, "Error: Argument must be numeric")
-  expect_error(assert_is_numeric(2), "Assertion Function `function(x) x` must return TRUE / FALSE. Instead returned: `2`", fixed=TRUE)
+  expect_snapshot(assert_is_numeric(2), error = TRUE)
 })
+
+
+cli::test_that_cli(configs = "plain", "assertion function aborts if func returns FALSE without a default error message", {
+  # Bad assertion: returns FALSE with no default error message
+  bad_assert_no_default_error <- assert_create(function(x) FALSE)
+  expect_snapshot(bad_assert_no_default_error(2), error = TRUE)
+
+  # Good assertion: returns STRING with no default error message
+  good_assert_no_default_error <- assert_create(function(x) "an error message")
+  expect_snapshot(good_assert_no_default_error(2), error = TRUE)
+})
+
+cli::test_that_cli(configs = "plain", "assertion function throws appropriate error when returning neither a flag NOR a string", {
+  # Bad assertion: returns character not string
+  bad_assert_returns_char <- assert_create(function(x) c("a", "b"))
+  expect_snapshot(bad_assert_returns_char("foo"), error = TRUE)
+
+  # Bad assertion: returns logical not flag
+  bad_assert_returns_logical <- assert_create(function(x) c(TRUE, TRUE))
+  expect_snapshot(bad_assert_returns_logical("foo"), error = TRUE)
+
+  # Bad assertion: returns factor
+  bad_assert_returns_factor <- assert_create(function(x) factor(c(1, 4)))
+  expect_snapshot(bad_assert_returns_factor("foo"), error = TRUE)
+
+})
+
+cli::test_that_cli(configs = "plain", "assertion function works as expected with string-returning assertion functions", {
+  # Bad assertion: returns character not string
+  is_between_min_and_max <- function(obj, min, max){
+    if(!is.numeric(obj)) return(paste0("{arg_name} is a {class(arg_value)}, not numeric"))
+
+    if(obj > max) return("{arg_name} is over {max}")
+    else if (obj < min) return("{arg_name} is under {min}")
+
+    return(TRUE)
+  }
+
+  assert_between_min_and_max <- assert_create(is_between_min_and_max)
+  expect_true(assert_between_min_and_max(4, min = 3, max = 5))
+
+  expect_snapshot(assert_between_min_and_max("foo", min = 3, max = 5), error = TRUE)
+  expect_snapshot(assert_between_min_and_max(6, min = 3, max = 5), error = TRUE)
+  expect_snapshot(assert_between_min_and_max(2, min = 3, max = 5), error = TRUE)
+})
+
 
 
 # Test Creation of Assertion Chains  -----------------------------------------------------

--- a/vignettes/create_custom_assertions.Rmd
+++ b/vignettes/create_custom_assertions.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 
 ## Getting Started
 
-Do you have a custom assertion that you want to use repeatedly in your code? Then create your own assertion functions with the `assert_create()` function!.
+Do you have a custom assertion that you want to use repeatedly in your code? Then create your own assertion functions with the `assert_create()` function!
 
 Lets start by recreating the `assert_numeric()` assertion using `assert_create()`:
 
@@ -80,4 +80,54 @@ assert_string(3)
 # Output: Error: '3' must be a character
 ```
 
+
+## More Advanced Assertions
+
+**Problem:**
+
+We often need error messages to vary significantly based on the input. 
+
+**Solution**
+
+In such cases, it is more convenient to define the error messages in the function you pass to `func`. 
+How does this work?
+
+In our call to `assert_create`, instead of defining a `default_error_msg`, we can design `func` to return a string when the assertion should fail. This string will become the error message. By returning different strings upon different failure conditions, we can produce very diverse error messages very easily.
+
+**Example**
+
+Here's a recreation of the example above, using a `func` that supplies strings to indicate assertion failure
+
+```{r, eval=FALSE}
+# Define Function
+is_a_string <- function(object){
+ if(!is.character(object))
+   return("{arg_name} must be a character, not class({arg_value})")
+  
+  if(length(object) != 1){
+    return("{arg_name} must be length 1, not {length(object)}")
+  }
+  
+  return(TRUE)
+}
+
+# Create Assertion
+assert_is_string <- assert_create(
+ is_a_string
+)
+
+# Test assertion works
+assert_is_string("String")
+
+assert_is_string(3)
+# 3 must be a character, not numeric
+
+assert_is_string(c("A", "B"))
+```
+
+**Additional Notes**
+
+Note that in your error strings can use the special terms such as `{arg_name}`, but you will NOT have access to the first argument using its original name (e.g. `{object}`, in the example above). This is because assert_create changes this first arguments name.
+
+Values of all other arguments can be referred to in string using `{name_of_nonfirst_argument}`
 


### PR DESCRIPTION
changed `assert_create` functionality:
If function `func` returns a string, the assertion fails and the string becomes the error message.

Vignettes, documentation and unit tests have been updated