### PR TITLE
Refine matrix element type message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 
 * Improved error messages when `assert_create()` arguments are inappropriate
 
+* Improved `assert_numeric()` error messaging for non-numeric matrices/arrays
+
 # assertions 0.1.0
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/assert_type.R
+++ b/R/assert_type.R
@@ -170,7 +170,7 @@ assert_factor_vector <- assert_create(is.factor, default_error_msg = msg_helper_
 #'
 #' @concept assert_type
 #' @export
-assert_numeric <- assert_create(is.numeric, default_error_msg = msg_helper_assert_type("numeric", a = FALSE))
+assert_numeric <- assert_create(is_numeric_with_matrix_message, default_error_msg = msg_helper_assert_type("numeric", a = FALSE))
 
 ## numeric vector -----------------------------------------------------------
 #' Assert input is a numeric vector
@@ -597,4 +597,3 @@ assert_connection <- assert_create(
   func = is_connection,
   default_error_msg = msg_helper_assert_type("database connection")
 )
-

--- a/R/is_functions.R
+++ b/R/is_functions.R
@@ -35,6 +35,19 @@ is_numeric_vector <- function(x){
   is.numeric(x) && is_vector(x)
 }
 
+is_numeric_with_matrix_message <- function(x){
+  if(is.numeric(x))
+    return(TRUE)
+
+  if(is.matrix(x) || is.array(x)){
+    structure_type <- if (is.matrix(x)) "matrix" else "array"
+    element_type <- typeof(x)
+    return(paste0("'{.strong {arg_name}}' must be numeric, not a {.strong ", element_type, "} ", structure_type))
+  }
+
+  return(FALSE)
+}
+
 
 #' Check if an object is a single number
 #'
@@ -258,6 +271,3 @@ is_non_empty_string_advanced <- function(x){
 
   return(invisible(TRUE))
 }
-
-
-

--- a/tests/testthat/test-assert_type.R
+++ b/tests/testthat/test-assert_type.R
@@ -120,6 +120,7 @@ cli::test_that_cli("assert_numeric() works", configs = "plain", {
   expect_identical(assert_numeric(matrix(1:9, 3)), TRUE)
 
   # Aborts for non-numeric objects
+  expect_error(assert_numeric(matrix(LETTERS[1:5])), "'matrix(LETTERS[1:5])' must be numeric, not a character matrix", fixed = TRUE)
   expect_error(assert_numeric(c("a", "b", "c")), "'c(\"a\", \"b\", \"c\")' must be numeric, not a character", fixed = TRUE)
   expect_error(assert_numeric(factor(c(1, 2, 3))), "'factor(c(1, 2, 3))' must be numeric, not a factor", fixed = TRUE)
   expect_error(assert_numeric(data.frame(a = 1, b = 2)), "'data.frame(a = 1, b = 2)' must be numeric, not a data.frame", fixed = TRUE)
@@ -548,6 +549,5 @@ cli::test_that_cli("assert_connection() works", configs = "plain", {
   # Custom error messages work
   expect_error(assert_connection(42, msg = "Custom error message"), "Custom error message")
 })
-
 
 


### PR DESCRIPTION
### Motivation
- Improve clarity of non-numeric matrix/array error messages by extracting and using the element type when formatting the message in the numeric check.

### Description
- Update `is_numeric_with_matrix_message` in `R/is_functions.R` to store `element_type <- typeof(x)` and use it when constructing the matrix/array error string.

### Testing
- Ran `devtools::document()` which completed successfully; ran `devtools::test()` and all tests passed (1006 tests passed); ran `devtools::check()` which completed but reported 1 WARNING (`qpdf` not available) and 1 NOTE (unable to verify current time), causing `R CMD check` to return with warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6989a803633c83339ed1642c38df2bcd)