### PR TITLE
Validate missing threshold inputs for length and comparison assertions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * Improved missing-value errors for numeric comparison assertions (e.g., `assert_greater_than()` with `NaN`)
 
+* Improved threshold validation so missing `length`, `minimum`, and `maximum` arguments now return informative assertion errors instead of base R missing-value failures
+
 * Improved `assert_numeric()` error messaging for non-numeric matrices/arrays
 
 # assertions 0.2.0

--- a/R/assert_compare.R
+++ b/R/assert_compare.R
@@ -1,3 +1,36 @@
+# Comparison threshold checks ---------------------------------------------
+
+validate_minimum <- assert_create(function(x, minimum){
+  if(!is.numeric(minimum)) return("'minimum' must be numeric")
+  if(length(minimum) != 1) return("'minimum' must be a single number")
+  if(is.na(minimum) || is.nan(minimum)) return("'minimum' must not be missing")
+  TRUE
+})
+
+validate_maximum <- assert_create(function(x, maximum){
+  if(!is.numeric(maximum)) return("'maximum' must be numeric")
+  if(length(maximum) != 1) return("'maximum' must be a single number")
+  if(is.na(maximum) || is.nan(maximum)) return("'maximum' must not be missing")
+  TRUE
+})
+
+validate_between_thresholds <- assert_create(function(x, minimum, maximum, inclusive = TRUE){
+  if(!is.numeric(minimum)) return("'minimum' must be numeric")
+  if(length(minimum) != 1) return("'minimum' must be a single number")
+  if(is.na(minimum) || is.nan(minimum)) return("'minimum' must not be missing")
+
+  if(!is.numeric(maximum)) return("'maximum' must be numeric")
+  if(length(maximum) != 1) return("'maximum' must be a single number")
+  if(is.na(maximum) || is.nan(maximum)) return("'maximum' must not be missing")
+
+  if(!is.logical(inclusive)) return("'inclusive' must be logical")
+  if(length(inclusive) != 1) return("'inclusive' must be a single logical value")
+  if(is.na(inclusive)) return("'inclusive' must not be missing")
+
+  TRUE
+})
+
+
 #' Assert input is greater than a specified minimum value
 #'
 #' Assert all elements in a numeric vector/matrix are above some minimum value.
@@ -28,6 +61,7 @@
 assert_all_greater_than <- assert_create_chain(
   assert_numeric,
   assert_no_missing,
+  validate_minimum,
   assert_create(
     is_greater_than,
     default_error_msg = "{.strong {arg_name}} must {ifelse(length(arg_value) > 1, 'all ', '')}be {.strong greater than} `{.strong {minimum}}`."
@@ -87,6 +121,7 @@ assert_greater_than <- assert_create_chain(
 assert_all_greater_than_or_equal_to <- assert_create_chain(
   assert_numeric,
   assert_no_missing,
+  validate_minimum,
   assert_create(
     is_greater_than_or_equal_to,
     default_error_msg = "{.strong {arg_name}} must {ifelse(length(arg_value) > 1, 'all ', '')}be {.strong greater than or equal to} `{.strong {minimum}}`."
@@ -205,6 +240,7 @@ assert_equal <- assert_create(is_equal, default_error_msg = "{.strong {arg_name}
 assert_all_less_than <- assert_create_chain(
   assert_numeric,
   assert_no_missing,
+  validate_maximum,
   assert_create(
     is_less_than,
     default_error_msg = "{.strong {arg_name}} must {ifelse(length(arg_value) > 1, 'all ', '')}be {.strong less than} `{.strong {maximum}}`."
@@ -264,6 +300,7 @@ assert_less_than <- assert_create_chain(
 assert_all_less_than_or_equal_to <- assert_create_chain(
   assert_numeric,
   assert_no_missing,
+  validate_maximum,
   assert_create(
     is_less_than_or_equal_to,
     default_error_msg = "{.strong {arg_name}} must {ifelse(length(arg_value) > 1, 'all ', '')}be {.strong less than or equal to} `{.strong {maximum}}`."
@@ -321,6 +358,7 @@ assert_less_than_or_equal_to <- assert_create_chain(
 assert_all_between <- assert_create_chain(
   assert_numeric,
   assert_no_missing,
+  validate_between_thresholds,
   assert_create(
     is_between,
     default_error_msg = "{.strong {arg_name}} must {ifelse(length(arg_value) > 1, 'all ', '')}be {.strong between} {.strong {minimum}} and {.strong {maximum}} {ifelse(inclusive, '(inclusive)', '(exclusive)')}."
@@ -353,6 +391,7 @@ assert_all_between <- assert_create_chain(
 assert_between <- assert_create_chain(
   assert_number,
   assert_no_missing,
+  validate_between_thresholds,
   assert_create(
     is_between,
     default_error_msg = "{.strong {arg_name}} must be {.strong between} {.strong {minimum}} and {.strong {maximum}} {ifelse(inclusive, '(inclusive)', '(exclusive)')}."

--- a/R/assert_length.R
+++ b/R/assert_length.R
@@ -16,6 +16,7 @@ assert_length <- assert_create(
   func = function(x, length) {
     if(!is.numeric(length)) return("'length' must be numeric")
     if(length(length) != 1) return("'length' must be a single number")
+    if(is.na(length) || is.nan(length)) return("'length' must not be missing")
     if(!is_whole_number(length)) return("'length' must be a whole number")
     if(length < 0) return("'length' must be non-negative")
     
@@ -35,6 +36,7 @@ assert_length_greater_than <- assert_create(
   func = function(x, length) {
     if(!is.numeric(length)) return("'length' must be numeric")
     if(length(length) != 1) return("'length' must be a single number")
+    if(is.na(length) || is.nan(length)) return("'length' must not be missing")
     if(!is_whole_number(length)) return("'length' must be a whole number")
     if(length < 0) return("'length' must be non-negative")
     
@@ -54,6 +56,7 @@ assert_length_greater_than_or_equal_to <- assert_create(
   func = function(x, length) {
     if(!is.numeric(length)) return("'length' must be numeric")
     if(length(length) != 1) return("'length' must be a single number")
+    if(is.na(length) || is.nan(length)) return("'length' must not be missing")
     if(!is_whole_number(length)) return("'length' must be a whole number")
     if(length < 0) return("'length' must be non-negative")
     
@@ -73,6 +76,7 @@ assert_length_less_than <- assert_create(
   func = function(x, length) {
     if(!is.numeric(length)) return("'length' must be numeric")
     if(length(length) != 1) return("'length' must be a single number")
+    if(is.na(length) || is.nan(length)) return("'length' must not be missing")
     if(!is_whole_number(length)) return("'length' must be a whole number")
     if(length < 0) return("'length' must be non-negative")
     
@@ -92,6 +96,7 @@ assert_length_less_than_or_equal_to <- assert_create(
   func = function(x, length) {
     if(!is.numeric(length)) return("'length' must be numeric")
     if(length(length) != 1) return("'length' must be a single number")
+    if(is.na(length) || is.nan(length)) return("'length' must not be missing")
     if(!is_whole_number(length)) return("'length' must be a whole number")
     if(length < 0) return("'length' must be non-negative")
     

--- a/R/is_functions.R
+++ b/R/is_functions.R
@@ -161,7 +161,7 @@ is_reactive <- function(x){
 }
 
 is_whole_number <- function(x){
-  return(x%%1==0)
+  is.numeric(x) && length(x) == 1 && !is.na(x) && is.finite(x) && x%%1 == 0
 }
 
 is_all_finite <- function(x){

--- a/tests/testthat/test-assert_compare.R
+++ b/tests/testthat/test-assert_compare.R
@@ -213,6 +213,26 @@ cli::test_that_cli("numeric comparison assertions reject NaN with a missing-valu
   expect_error(assert_all_between(c(1, NaN), 0, 2), "must have no missing values", fixed = FALSE)
 })
 
+
+cli::test_that_cli("numeric comparison assertions validate missing threshold values", config = "plain", {
+  expect_error(assert_greater_than(5, NA_real_), "'minimum' must not be missing", fixed = TRUE)
+  expect_error(assert_all_greater_than(c(5, 6), NaN), "'minimum' must not be missing", fixed = TRUE)
+
+  expect_error(assert_greater_than_or_equal_to(5, NA_real_), "'minimum' must not be missing", fixed = TRUE)
+  expect_error(assert_all_greater_than_or_equal_to(c(5, 6), NaN), "'minimum' must not be missing", fixed = TRUE)
+
+  expect_error(assert_less_than(5, NA_real_), "'maximum' must not be missing", fixed = TRUE)
+  expect_error(assert_all_less_than(c(5, 6), NaN), "'maximum' must not be missing", fixed = TRUE)
+
+  expect_error(assert_less_than_or_equal_to(5, NA_real_), "'maximum' must not be missing", fixed = TRUE)
+  expect_error(assert_all_less_than_or_equal_to(c(5, 6), NaN), "'maximum' must not be missing", fixed = TRUE)
+
+  expect_error(assert_between(5, NA_real_, 6), "'minimum' must not be missing", fixed = TRUE)
+  expect_error(assert_between(5, 1, NaN), "'maximum' must not be missing", fixed = TRUE)
+  expect_error(assert_all_between(c(2, 3), NA_real_, 4), "'minimum' must not be missing", fixed = TRUE)
+  expect_error(assert_all_between(c(2, 3), 1, NaN), "'maximum' must not be missing", fixed = TRUE)
+})
+
 cli::test_that_cli("assert_identical() works", config = "plain", {
 
   # Passes

--- a/tests/testthat/test-assert_length.R
+++ b/tests/testthat/test-assert_length.R
@@ -13,6 +13,8 @@ cli::test_that_cli("assert_length() works", configs = "plain", {
   expect_error(assert_length(1:3, "3"), "'length' must be numeric", fixed = TRUE)
   expect_error(assert_length(1:3, c(2, 3)), "'length' must be a single number", fixed = TRUE)
   expect_error(assert_length(1:3, 2.5), "'length' must be a whole number", fixed = TRUE)
+  expect_error(assert_length(1:3, NA_real_), "'length' must not be missing", fixed = TRUE)
+  expect_error(assert_length(1:3, NaN), "'length' must not be missing", fixed = TRUE)
   expect_error(assert_length(1:3, -1), "'length' must be non-negative", fixed = TRUE)
   
   # Error messages use variable name
@@ -36,6 +38,8 @@ cli::test_that_cli("assert_length_greater_than() works", configs = "plain", {
   expect_error(assert_length_greater_than(1:3, "3"), "'length' must be numeric", fixed = TRUE)
   expect_error(assert_length_greater_than(1:3, c(2, 3)), "'length' must be a single number", fixed = TRUE)
   expect_error(assert_length_greater_than(1:3, 2.5), "'length' must be a whole number", fixed = TRUE)
+  expect_error(assert_length_greater_than(1:3, NA_real_), "'length' must not be missing", fixed = TRUE)
+  expect_error(assert_length_greater_than(1:3, NaN), "'length' must not be missing", fixed = TRUE)
   expect_error(assert_length_greater_than(1:3, -1), "'length' must be non-negative", fixed = TRUE)
 })
 
@@ -52,6 +56,8 @@ cli::test_that_cli("assert_length_greater_than_or_equal_to() works", configs = "
   expect_error(assert_length_greater_than_or_equal_to(1:3, "3"), "'length' must be numeric", fixed = TRUE)
   expect_error(assert_length_greater_than_or_equal_to(1:3, c(2, 3)), "'length' must be a single number", fixed = TRUE)
   expect_error(assert_length_greater_than_or_equal_to(1:3, 2.5), "'length' must be a whole number", fixed = TRUE)
+  expect_error(assert_length_greater_than_or_equal_to(1:3, NA_real_), "'length' must not be missing", fixed = TRUE)
+  expect_error(assert_length_greater_than_or_equal_to(1:3, NaN), "'length' must not be missing", fixed = TRUE)
   expect_error(assert_length_greater_than_or_equal_to(1:3, -1), "'length' must be non-negative", fixed = TRUE)
 })
 
@@ -68,6 +74,8 @@ cli::test_that_cli("assert_length_less_than() works", configs = "plain", {
   expect_error(assert_length_less_than(1:3, "3"), "'length' must be numeric", fixed = TRUE)
   expect_error(assert_length_less_than(1:3, c(2, 3)), "'length' must be a single number", fixed = TRUE)
   expect_error(assert_length_less_than(1:3, 2.5), "'length' must be a whole number", fixed = TRUE)
+  expect_error(assert_length_less_than(1:3, NA_real_), "'length' must not be missing", fixed = TRUE)
+  expect_error(assert_length_less_than(1:3, NaN), "'length' must not be missing", fixed = TRUE)
   expect_error(assert_length_less_than(1:3, -1), "'length' must be non-negative", fixed = TRUE)
 })
 
@@ -84,5 +92,7 @@ cli::test_that_cli("assert_length_less_than_or_equal_to() works", configs = "pla
   expect_error(assert_length_less_than_or_equal_to(1:3, "3"), "'length' must be numeric", fixed = TRUE)
   expect_error(assert_length_less_than_or_equal_to(1:3, c(2, 3)), "'length' must be a single number", fixed = TRUE)
   expect_error(assert_length_less_than_or_equal_to(1:3, 2.5), "'length' must be a whole number", fixed = TRUE)
+  expect_error(assert_length_less_than_or_equal_to(1:3, NA_real_), "'length' must not be missing", fixed = TRUE)
+  expect_error(assert_length_less_than_or_equal_to(1:3, NaN), "'length' must not be missing", fixed = TRUE)
   expect_error(assert_length_less_than_or_equal_to(1:3, -1), "'length' must be non-negative", fixed = TRUE)
 })

--- a/tests/testthat/test-is_functions.R
+++ b/tests/testthat/test-is_functions.R
@@ -113,6 +113,10 @@ test_that("is_whole_number works as expected", {
   expect_false(is_whole_number(2.5))
   expect_true(is_whole_number(0))
   expect_true(is_whole_number(-3))
+  expect_false(is_whole_number(NA_real_))
+  expect_false(is_whole_number(NaN))
+  expect_false(is_whole_number(Inf))
+  expect_false(is_whole_number(c(1, 2)))
 })
 
 # Test `is_connection` (requires DBI)


### PR DESCRIPTION
### Motivation
- Improve error messages when callers pass `NA`/`NaN` as threshold arguments to length/comparison assertions by surfacing clear assertion errors.
- Centralize and harden threshold validation for numeric comparison assertions so comparisons never execute with missing/non-finite thresholds.
- Ensure helper predicates return strict logical scalars so downstream checks behave deterministically.

### Description
- Added explicit missing/NaN guards to all `assert_length*()` variants so `length = NA`/`NaN` returns `"'length' must not be missing"` rather than causing `missing value where TRUE/FALSE needed` (changes in `R/assert_length.R`).
- Introduced `validate_minimum`, `validate_maximum`, and `validate_between_thresholds` small validators and wired them into comparison assertion chains (`assert_all_*` and `assert_between`/`assert_all_between`) to validate `minimum`, `maximum`, and `inclusive` before comparisons (changes in `R/assert_compare.R`).
- Hardened `is_whole_number()` to return a strict logical scalar and treat missing/non-finite/non-scalar values as `FALSE` (change in `R/is_functions.R`).
- Added regression tests covering missing `length`, `minimum`, `maximum`, and updated `is_whole_number()` expectations (changes in `tests/testthat/`), and updated `NEWS.md` to document the user-visible behavior fix.

### Testing
- Ran `devtools::document()` successfully to update docs.
- Ran `devtools::test()` and all tests passed after fixes (final test run reported all tests passing).
- Ran `devtools::check()`; package build and checks executed but `R CMD check` reported one warning about missing system `qpdf` and one note about time verification, causing `devtools::check()` to exit with a non-zero status due to the warning; the code changes themselves did not produce R errors during checks.  
- Performed targeted runtime spot-checks via `devtools::load_all()` for `assert_length(..., NaN)`, `assert_greater_than(..., NaN)`, and `assert_between(..., maximum = NaN)` which returned the new informative assertion messages as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698c54f3bf088333a811f85b634e3c1a)